### PR TITLE
Remove dependency to fastlane

### DIFF
--- a/fastlane-plugin-firim/fastlane-plugin-firim.gemspec
+++ b/fastlane-plugin-firim/fastlane-plugin-firim.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'fastlane', '>= 1.104.0'
 end


### PR DESCRIPTION
With an upcoming _fastlane_ release it is important to remove the dependency to _fastlane_ and _fastlane_core_, see https://github.com/fastlane/fastlane/issues/7412 for more information