### PR TITLE
Make the fastlane gem dependency less strict

### DIFF
--- a/firim.gemspec
+++ b/firim.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # fastlane dependencies
-  spec.add_dependency 'fastlane', '~> 2.1.0'
+  spec.add_dependency 'fastlane', '>= 2.1.0', '< 3.0.0'
   spec.add_dependency 'faraday', '~> 0.9'
   spec.add_dependency 'faraday_middleware', '~> 0.9'
 


### PR DESCRIPTION
`firim` and its fastlane plugin can't be used with current versions of _fastlane_ because of the strict gem dependency in the `firim` gemspec.

That problem appears like this:

```
[10:28:16]: Successfully installed 'fastlane-plugin-firim'
/Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:2284:in `raise_if_conflicts': Unable to activate firim-0.1.2, because fastlane-2.6.0 conflicts with fastlane (~> 2.1.0) (Gem::ConflictError)
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:1407:in `activate'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:1441:in `block in activate_dependencies'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:1427:in `each'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:1427:in `activate_dependencies'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/2.3.0/rubygems/specification.rb:1409:in `activate'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/2.3.0/rubygems.rb:196:in `rescue in try_activate'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/2.3.0/rubygems.rb:193:in `try_activate'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:125:in `rescue in require'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:40:in `require'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.6.0/fastlane/lib/fastlane/fastlane_require.rb:38:in `install_gem_if_needed'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.6.0/fastlane/lib/fastlane/plugins/plugin_manager.rb:276:in `block in load_plugins'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.6.0/fastlane/lib/fastlane/plugins/plugin_manager.rb:268:in `each'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.6.0/fastlane/lib/fastlane/plugins/plugin_manager.rb:268:in `load_plugins'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.6.0/fastlane/lib/fastlane/environment_printer.rb:56:in `print_loaded_plugins'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.6.0/fastlane/lib/fastlane/environment_printer.rb:27:in `get'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.6.0/fastlane/lib/fastlane/environment_printer.rb:4:in `output'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.6.0/fastlane/lib/fastlane/commands_generator.rb:223:in `block (2 levels) in run'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/commander-4.4.3/lib/commander/command.rb:178:in `call'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/commander-4.4.3/lib/commander/command.rb:153:in `run'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/commander-4.4.3/lib/commander/runner.rb:446:in `run_active_command'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.6.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:38:in `run!'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/commander-4.4.3/lib/commander/delegates.rb:15:in `run!'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.6.0/fastlane/lib/fastlane/commands_generator.rb:293:in `run'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.6.0/fastlane/lib/fastlane/commands_generator.rb:36:in `start'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.6.0/fastlane/lib/fastlane/cli_tools_distributor.rb:59:in `take_off'
	from /Users/mfurtak/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fastlane-2.6.0/bin/fastlane:15:in `<top (required)>'
	from /Users/mfurtak/.rbenv/versions/2.3.1/bin/fastlane:23:in `load'
	from /Users/mfurtak/.rbenv/versions/2.3.1/bin/fastlane:23:in `<main>'
```

Unless there's something specific to _fastlane_ 2.1, I think the proposed version range will be more correct and flexible for your users 👍 